### PR TITLE
chore/fix: Export types, make public domain, rm superfluous tslib dep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Use nodejs
       uses: actions/setup-node@v2
       with:
-        node-version: '16'
+        node-version: '20'
         cache: 'npm'
 
     - name: Install deps without updating package-lock.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,30 +1,24 @@
-Copyright (c) 2019, Robert Pearce
+This is free and unencumbered software released into the public domain.
 
-All rights reserved.
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
 
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
 
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of Robert Pearce nor the names of other
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+For more information, please refer to <https://unlicense.org>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "react-with-forwarded-ref",
       "version": "1.0.0",
       "license": "BSD-3",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.2.0",
@@ -7686,11 +7683,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-    },
     "node_modules/tsutils": {
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
@@ -13905,11 +13897,6 @@
           "dev": true
         }
       }
-    },
-    "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "contributors": [
     "Robert Pearce <me@robertwpearce.com> (https://robertwpearce.com)"
   ],
-  "license": "BSD-3",
+  "license": "Unlicense",
   "keywords": [
     "forwardRef",
     "react",

--- a/package.json
+++ b/package.json
@@ -77,8 +77,5 @@
   },
   "peerDependencies": {
     "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
-  },
-  "dependencies": {
-    "tslib": "^2.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./dist/index.js"
   },
+  "types": "./dist/index.d.ts",
   "type": "module",
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "allowSyntheticDefaultImports": true,
     "declaration": true,
     "esModuleInterop": true,
-    "importHelpers": true,
     "jsx": "react",
     "lib": ["esnext", "dom"],
     "module": "esnext",


### PR DESCRIPTION
## Description

* Switches to more permissive, public domain "Unlicense" license
* Makes sure we're pointing to the types output in `package.json`
* Remove superfluous dep on `tslib`

Given there are no API changes, and the going to a _more_ permissive license, I'm going to update these as a patch. Part of me thinks any `LICENSE` change should be a major bump, but I think this doesn't restrict anyone so don't consider it breaking.